### PR TITLE
Corretly serialize and deserialize multiple print areas on one worksheet

### DIFF
--- a/lib/xlsx/xform/book/workbook-xform.js
+++ b/lib/xlsx/xform/book/workbook-xform.js
@@ -45,21 +45,16 @@ class WorkbookXform extends BaseXform {
         const definedName = {
           name: '_xlnm.Print_Area',
           localSheetId: index,
-          ranges:[]
+          ranges: [],
         };
         sheet.pageSetup.printArea.split('&&').forEach(printArea => {
           const printAreaComponents = printArea.split(':');
-          definedName.ranges.push(
-            `'${sheet.name}'!$${printAreaComponents[0]}:$${printAreaComponents[1]}`
-          );
+          definedName.ranges.push(`'${sheet.name}'!$${printAreaComponents[0]}:$${printAreaComponents[1]}`);
         });
         printAreas.push(definedName);
       }
 
-      if (
-        sheet.pageSetup &&
-        (sheet.pageSetup.printTitlesRow || sheet.pageSetup.printTitlesColumn)
-      ) {
+      if (sheet.pageSetup && (sheet.pageSetup.printTitlesRow || sheet.pageSetup.printTitlesColumn)) {
         const ranges = [];
 
         if (sheet.pageSetup.printTitlesColumn) {

--- a/spec/integration/pr/new/test-new-pr-17.spec.js
+++ b/spec/integration/pr/new/test-new-pr-17.spec.js
@@ -1,0 +1,20 @@
+const ExcelJS = verquire('exceljs');
+
+// const NEW_TEST_17_XLSX_FILE_NAME = './spec/integration/data/test-new-pr-17.xlsx';
+
+describe('new pr related issues', () => {
+  describe('new pr 17 serialize and deserialize multiple print areas on one worksheet', () => {
+    it('Multiple print areas can be correctly read to settings', async () => {
+      const wb = new ExcelJS.Workbook();
+      const ws = wb.addWorksheet('sheet');
+      const writePrintArea = 'A2:B5&&A7:B10&&A13:B17';
+      ws.pageSetup.printArea = writePrintArea;
+      //   await wb.xlsx.writeFile(NEW_TEST_17_XLSX_FILE_NAME);
+      const buffer = await wb.xlsx.writeBuffer();
+      await wb.xlsx.load(buffer);
+      const worksheet = wb.getWorksheet('sheet');
+      const readPintArea = worksheet.pageSetup.printArea;
+      expect(writePrintArea).to.equal(readPintArea);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

In order to solve the missing multi print-area in a single sheet of export .xlsx file.

## Test plan

Refer to the test plan of the original PR of `exceljs` (below)

## Related to source code (for typings update)

Solution based on: https://github.com/exceljs/exceljs/pull/1516
