### PR TITLE
fix(4.4.9): 修复读取文件，没有获取到内部超链接问题

### DIFF
--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -515,6 +515,15 @@ class WorkSheetXform extends BaseXform {
     options.hyperlinkMap = (model.hyperlinks || []).reduce((h, hyperlink) => {
       if (hyperlink.rId) {
         h[hyperlink.address] = rels[hyperlink.rId].Target;
+      } else if (hyperlink.target) {
+        // 支持内部超链接（如location="Sheet1!A1"）
+        let target = hyperlink.target;
+        if (target.includes('!')) {
+          // 形如 SheetName!A1，转为 #\'SheetName\'!A1
+          const [sheet, cellRef] = target.split('!');
+          target = `#'${sheet}'!${cellRef}`;
+        }
+        h[hyperlink.address] = target;
       }
       return h;
     }, {});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

当前 ExcelJS 在读取 Excel 文件时，无法正确解析单元格内的内部超链接（如跳转到同一工作簿中其他单元格的超链接）。这导致用户在使用 ExcelJS 处理含有内部导航链接的 Excel 文件时，丢失了这部分信息，影响了功能完整性。

本 PR 旨在修复该问题，通过更新解析逻辑，确保 ExcelJS 能够正确识别并还原 Excel 文件中的内部超链接。这一改动提升了库对 Excel 功能的支持完整性，使开发者能够更准确地读取和处理复杂 Excel 文件中的内容。

## Test plan

为验证此更改的有效性，我进行了以下测试步骤：

准备一个包含多种类型超链接的 Excel 文件（包括外部 URL、内部锚点、邮件链接等）。
使用修改后的 ExcelJS 版本读取该文件。
输出每个单元格的 hyperlink 属性进行检查。

## Related to source code (for typings update)
